### PR TITLE
Fix violation about OWASP2021.A5.NCE

### DIFF
--- a/src/main/java/com/parasoft/report/transformer/XMLToSarif.java
+++ b/src/main/java/com/parasoft/report/transformer/XMLToSarif.java
@@ -68,7 +68,7 @@ public class XMLToSarif implements Callable<Integer> {
             this.convertXmlToSarif();
 
             return 0;
-        } catch (Exception e) {
+        } catch (Exception e) { // parasoft-suppress OWASP2021.A5.NCE "This is intentionally designed to prevent exceptions from bubbling up and causing the program to terminate."
             Logger.error(MessageFormat.format("ERROR: {0}", e.getMessage()));
             return 1;
         }


### PR DESCRIPTION
Two violations reported in [DTP]

* _OWASP2021.A5.NCE_
**Current solution:** Suppressed
* _PB.USC.FCBS_
**Current solution:** Update [rule parameter](https://dtp.parasoftcn.com/grs/dtp/testConfigurations#/tool/1/configuration/98/rule/PB.USC.FCBS) by adding '_picocli.CommandLine.Option_' in the **Ignore annotations that correspond to these qualified names** field

