### PR TITLE
Update jackson to fix CVE-2025-52999

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.tinylog:tinylog-impl:2.7.0'
     implementation 'net.sf.saxon:Saxon-HE:12.2'
     implementation 'info.picocli:picocli:4.6.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
     annotationProcessor 'info.picocli:picocli-codegen:4.6.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'


### PR DESCRIPTION
Update `com.fasterxml.jackson.core:jackson-databind` dependency to the latest release.